### PR TITLE
deal with some poorly documented quirks

### DIFF
--- a/XPlaneUdp.py
+++ b/XPlaneUdp.py
@@ -4,6 +4,7 @@
 import socket
 import struct
 import binascii
+from time import sleep
 
 class XPlaneIpNotFound(Exception):
   args="Could not find any running XPlane instance in network."
@@ -19,7 +20,6 @@ class XPlaneUdp:
   '''
   
   #constants
-  UDP_PORT = 49000
   MCAST_GRP = "239.255.1.1"
   MCAST_PORT = 49707 # (MCAST_PORT was 49000 for XPlane10)
   
@@ -67,12 +67,14 @@ class XPlaneUdp:
     string = dataref.encode()
     message = struct.pack("<5sii400s", cmd, freq, idx, string)
     assert(len(message)==413)
-    self.socket.sendto(message, (self.BeaconData["IP"], self.UDP_PORT))
+    self.socket.sendto(message, (self.BeaconData["IP"], self.BeaconData["Port"]))
+    if (self.datarefidx%100 == 0):
+      sleep(0.2)
 
   def GetValues(self):
     try:
       # Receive packet
-      data, addr = self.socket.recvfrom(1024) # buffer size is 1024 bytes
+      data, addr = self.socket.recvfrom(1472) # maximum bytes of an RREF answer X-Plane will send (Ethernet MTU - IP hdr - UDP hdr)
       # Decode Packet
       retvalues = {}
       # * Read the Header "RREFO".
@@ -119,7 +121,7 @@ class XPlaneUdp:
         
         # receive data
         try: 
-          packet, sender = sock.recvfrom(15000)
+          packet, sender = sock.recvfrom(1472)
 
           # decode data
           # * Header
@@ -193,6 +195,8 @@ if __name__ == '__main__':
         print(values)
       except XPlaneTimeout:
         print("XPlane Timeout")
+        exit(0)
 
   except XPlaneIpNotFound:
     print("XPlane IP not found. Probably there is no XPlane running in your local network.")
+    exit(0)


### PR DESCRIPTION
I found this little script incredibly helpful to test changes in X-Plane 11.10, and update the documentation. In fact, everything I wrote in the commit message will be in the official X-Plane documentation as well. This script has been helpful to make sure we didn't break anything.
We have used this script (with my changes in this pull request) to load X-Plane with thousands of RREFs to see whether it's working correctly.

X-Plane can be listening on a different UDP port than the default, if the user configured it this way. But thanks to the beacon, you will know which port the user set! So, you should not assume the X-Plane default port, but always use the one that the beacon packet tells you.

X-Plane will send at most 183 values in one RREF packet. That is because of the MTU of 1500 bytes on Ethernet. Subtract 20 bytes for the IP header, 8 bytes for the UDP header, and 5 bytes for the X-Plane header, you will have space for 183 values without fragmentation.

X-Plane will hold up to about 140 requests in the queue for one frame. So if you are requesting more than 140 RREFs, you should space the request out over more than one frame (50ms typically). I added code to wait after 100 requests.